### PR TITLE
Add basic test plus some refactors in the plugin side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# 1.1.0
+ - Add basic tests for the project
+ - Refactor the plugin to include the option to add an option to inject
+   a dummy bot.
+ - Refactor the plugin to have a cleaner shutdown methodology, so the
+   thread is not stuck waiting in the queue if there is no reason.

--- a/lib/logstash/inputs/irc.rb
+++ b/lib/logstash/inputs/irc.rb
@@ -55,6 +55,7 @@ class LogStash::Inputs::Irc < LogStash::Inputs::Base
 
   def inject_bot(bot)
     @bot = bot
+    self
   end
 
   def bot

--- a/logstash-input-irc.gemspec
+++ b/logstash-input-irc.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-irc'
-  s.version         = '1.0.0'
+  s.version         = '1.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read events from an IRC Server."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/irc_spec.rb
+++ b/spec/inputs/irc_spec.rb
@@ -2,17 +2,71 @@
 require_relative "../spec_helper"
 require "logstash/plugin"
 require "logstash/event"
+require "cinch"
 
 describe LogStash::Inputs::Irc do
 
   let(:properties) { {:name => "foo" } }
   let(:event)      { LogStash::Event.new(properties) }
 
-  let(:host)       { "freenode.org" }
+  let(:host)       { "irc.freenode.org" }
   let(:channels)   { ["foo", "bar"] }
 
   it "should register without errors" do
     plugin = LogStash::Plugin.lookup("input", "irc").new({ "host" => host, "channels" => channels })
     expect { plugin.register }.to_not raise_error
+  end
+
+  describe "receive" do
+
+    let(:config) { { "host" => host, "channels" => channels } }
+    subject      { LogStash::Inputs::Irc.new(config) }
+
+    let(:msg)    { double("message") }
+    let(:user)   { double("user") }
+
+    before(:each) do
+      allow(msg).to receive(:message).and_return("message")
+      allow(msg).to receive(:command).and_return("command")
+      allow(user).to receive(:host).and_return("host")
+      allow(user).to receive(:nick).and_return("nick")
+      allow(msg).to receive(:user).and_return(user)
+      allow(msg).to receive(:prefix).and_return("prefix")
+      allow(msg).to receive(:channel).and_return("channel")
+
+      subject.inject_bot(bot)
+      subject.register
+    end
+
+    let(:bot)     { Cinch::Bot.new }
+    let(:channel) { bot.handlers.find(:channel).first }
+    let(:nevents) { 1 }
+
+    let(:events) do
+      input(subject) do |queue|
+        nevents.times do
+          channel.call(msg, [], [])
+        end
+        result = nevents.times.inject([]) do |acc|
+          acc << queue.pop
+        end
+        result
+      end
+    end
+
+    let(:event) { events.first }
+
+    it "receive events from a channel" do
+      expect(event["channel"]).to eq("channel")
+    end
+
+    it "receive events with a command" do
+      expect(event["command"]).to eq("command")
+    end
+
+    it "receive events with nick information" do
+      expect(event["nick"]).to eq("nick")
+    end
+
   end
 end

--- a/spec/inputs/irc_spec.rb
+++ b/spec/inputs/irc_spec.rb
@@ -34,8 +34,7 @@ describe LogStash::Inputs::Irc do
       allow(msg).to receive(:prefix).and_return("prefix")
       allow(msg).to receive(:channel).and_return("channel")
 
-      subject.inject_bot(bot)
-      subject.register
+      subject.inject_bot(bot).register
     end
 
     let(:bot)     { Cinch::Bot.new }

--- a/spec/inputs/irc_spec.rb
+++ b/spec/inputs/irc_spec.rb
@@ -1,3 +1,18 @@
 # encoding: utf-8
-require "logstash/devutils/rspec/spec_helper"
-require 'logstash/inputs/irc'
+require_relative "../spec_helper"
+require "logstash/plugin"
+require "logstash/event"
+
+describe LogStash::Inputs::Irc do
+
+  let(:properties) { {:name => "foo" } }
+  let(:event)      { LogStash::Event.new(properties) }
+
+  let(:host)       { "freenode.org" }
+  let(:channels)   { ["foo", "bar"] }
+
+  it "should register without errors" do
+    plugin = LogStash::Plugin.lookup("input", "irc").new({ "host" => host, "channels" => channels })
+    expect { plugin.register }.to_not raise_error
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,24 @@
 # encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
 require 'logstash/inputs/irc'
+
+module IrcHelpers
+
+  def input(plugin, &block)
+    queue = Queue.new
+
+    input_thread = Thread.new do
+      plugin.run(queue)
+    end
+    result = block.call(queue)
+
+    plugin.teardown
+    input_thread.join
+    result
+  end
+
+end
+
+RSpec.configure do |c|
+  c.include IrcHelpers
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+# encoding: utf-8
+require "logstash/devutils/rspec/spec_helper"
+require 'logstash/inputs/irc'


### PR DESCRIPTION
Fixes #12 

changes in this PR include:
- Add basic tests for the project
- Refactor the plugin to include the option to add an option to inject a dummy bot.
- Refactor the plugin to have a cleaner shutdown methodology, so the thread is not stuck waiting in the queue if there is no reason.
