### PR TITLE
Make usage of the new stop semantics to properly shutdown the plugin

### DIFF
--- a/logstash-input-irc.gemspec
+++ b/logstash-input-irc.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
-
+  s.add_runtime_dependency 'stud', '~> 0.0.22'
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'cinch'
 

--- a/spec/inputs/irc_spec.rb
+++ b/spec/inputs/irc_spec.rb
@@ -17,6 +17,14 @@ describe LogStash::Inputs::Irc do
     expect { plugin.register }.to_not raise_error
   end
 
+  context "when stopping the plugin" do
+    it_behaves_like "an interruptible input plugin" do
+      let(:host)       { "irc.freenode.org" }
+      let(:channels)   { ["foo", "bar"] }
+      let(:config) { {  "host" => host, "channels" => channels, "get_stats" => true } }
+    end
+  end
+
   describe "receive" do
 
     let(:config) { { "host" => host, "channels" => channels } }
@@ -66,6 +74,5 @@ describe LogStash::Inputs::Irc do
     it "receive events with nick information" do
       expect(event["nick"]).to eq("nick")
     end
-
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@ module IrcHelpers
     end
     result = block.call(queue)
 
-    plugin.teardown
+    plugin.do_stop
     input_thread.join
     result
   end


### PR DESCRIPTION
Implements `stop` to return from `run` according to https://github.com/elastic/logstash/issues/3210

Depends on https://github.com/elastic/logstash-devutils/pull/32 and https://github.com/elastic/logstash/pull/3812

Fixes #14 

Depends on Stud::Task being properly setup to finish the task when requested (https://github.com/jordansissel/ruby-stud/issues/26)
