### PR TITLE
Make test pass within the context of the LS Core Defaults plugins test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+ - Fix the test to work properly within the context of the LS core
+   defaults plugin test.
+
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895

--- a/logstash-input-irc.gemspec
+++ b/logstash-input-irc.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-irc'
-  s.version         = '2.0.1'
+  s.version         = '2.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read events from an IRC Server."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/irc_spec.rb
+++ b/spec/inputs/irc_spec.rb
@@ -50,7 +50,7 @@ describe LogStash::Inputs::Irc do
     let(:nevents) { 1 }
 
     let(:events) do
-      input(subject) do |queue|
+      plugin_input(subject) do |queue|
         nevents.times do
           channel.call(msg, [], [])
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,24 +1,3 @@
 # encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
 require 'logstash/inputs/irc'
-
-module IrcHelpers
-
-  def input(plugin, &block)
-    queue = Queue.new
-
-    input_thread = Thread.new do
-      plugin.run(queue)
-    end
-    result = block.call(queue)
-
-    plugin.do_stop
-    input_thread.join
-    result
-  end
-
-end
-
-RSpec.configure do |c|
-  c.include IrcHelpers
-end


### PR DESCRIPTION
by having the custom helper moved into devutils and not doing more than one rspec.configure call.

Need https://github.com/elastic/logstash-devutils/pull/40 to work.
