### PR TITLE
FIX: don't peg CPU when caught up on IRC channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## UNRELEASED
+ - Fix bug where a connection to an idle IRC channel consumed 100% available CPU
+
 ## 3.0.5
   - Update gemspec summary
 


### PR DESCRIPTION
Ruby's `Queue` implementation has two options: blocking or non-blocking pops;
this plugin previously used non-blocking pops in order to simplify shutdown,
but when caught up on messages from the IRC channel, the tight loop around
non-blocking pops consumed 100% of available CPU.

By replacing the queue implementation with Java's `LinkedBlockingQueue`, which
has support for blocking polls with timeout, and selecting a poll duration of
1 second, we eliminate the tight loop while still supporting a graceful and
reasonably fast shutdown.

Fixes: logstash-plugins/logstash-input-irc#21