### PR TITLE
fix: ensure bot threads are cleaned up when input stops running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
  - Fix bug where a connection to an idle IRC channel consumed 100% available CPU
  - Fix issue where a message that did not contain a user's hostname could cause irc input to hang or crash
+ - Fix issue where IRC bots could be left running after a pipeline reload
 
 ## 3.0.5
   - Update gemspec summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## UNRELEASED
+## 3.0.6
  - Fix bug where a connection to an idle IRC channel consumed 100% available CPU
  - Fix issue where a message that did not contain a user's hostname could cause irc input to hang or crash
  - Fix issue where IRC bots could be left running after a pipeline reload

--- a/lib/logstash/inputs/irc.rb
+++ b/lib/logstash/inputs/irc.rb
@@ -116,6 +116,8 @@ class LogStash::Inputs::Irc < LogStash::Inputs::Base
       msg = @irc_queue.poll(1, java.util.concurrent.TimeUnit::SECONDS)
       handle_response(msg, output_queue) unless msg.nil?
     end
+  ensure
+    stop rescue logger.warn("irc input failed to shutdown gracefully: #{$!.message}")
   end # def run
 
   RPL_NAMREPLY = "353"
@@ -170,7 +172,7 @@ class LogStash::Inputs::Irc < LogStash::Inputs::Base
   end
 
   def stop
-    @request_names_thread.stop! if @request_names_thread
-    @bot_thread.stop!
+    @request_names_thread.stop! if @request_names_thread && !@request_names_thread.stop?
+    @bot_thread.stop! if @bot_thread && !@bot_thread.stop?
   end
 end # class LogStash::Inputs::Irc

--- a/logstash-input-irc.gemspec
+++ b/logstash-input-irc.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-irc'
-  s.version         = '3.0.5'
+  s.version         = '3.0.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from an IRC server"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Resolves: https://github.com/logstash-plugins/logstash-input-irc/issues/11