### PR TITLE
fix: use unsynced version of `host` attribute to workaround exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## UNRELEASED
  - Fix bug where a connection to an idle IRC channel consumed 100% available CPU
+ - Fix issue where a message that did not contain a user's hostname could cause irc input to hang or crash
 
 ## 3.0.5
   - Update gemspec summary

--- a/lib/logstash/inputs/irc.rb
+++ b/lib/logstash/inputs/irc.rb
@@ -148,7 +148,11 @@ class LogStash::Inputs::Irc < LogStash::Inputs::Base
           event.set("channel", msg.channel.to_s)
           event.set("nick", msg.user.nick)
           event.set("server", "#{@host}:#{@port}")
-          event.set("host", msg.user.host)
+          # The user's host attribute is an optional part of the message format;
+          # when it is not included, `Cinch::User#host` times out waiting for it
+          # to be populated, raising an exception; use `Cinch::User#data` to get
+          # host, which includes the user attributes as-parsed.
+          event.set("host", msg.user.data[:host])
           output_queue << event
         end
       end

--- a/spec/inputs/irc_spec.rb
+++ b/spec/inputs/irc_spec.rb
@@ -33,11 +33,13 @@ describe LogStash::Inputs::Irc do
     let(:msg)    { double("message") }
     let(:user)   { double("user") }
 
+    let(:user_data) { { host: "host", nick: "nick"} }
+
     before(:each) do
       allow(msg).to receive(:message).and_return("message")
       allow(msg).to receive(:command).and_return("command")
-      allow(user).to receive(:host).and_return("host")
-      allow(user).to receive(:nick).and_return("nick")
+      allow(user).to receive(:data).and_return(user_data)
+      allow(user).to receive(:nick).and_return(user_data[:nick])
       allow(msg).to receive(:user).and_return(user)
       allow(msg).to receive(:prefix).and_return("prefix")
       allow(msg).to receive(:channel).and_return("channel")
@@ -73,6 +75,19 @@ describe LogStash::Inputs::Irc do
 
     it "receive events with nick information" do
       expect(event.get("nick")).to eq("nick")
+    end
+
+    it "receive events with host information" do
+      expect(event.get("host")).to eq("host")
+    end
+
+    context "when host is unavailable" do
+
+      let(:user_data) { super().merge(host: nil)}
+
+      it "handles unknown host well" do
+        expect(event.get("host")).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
When a `Cinch::User#host` is sent, and the underlying attribute is not
populated, Cinch raises a `Cinch::Exceptions::SyncedAttributeNotAvailable`
exception after timing out waiting for a synchronisation that may never
happen.

Instead, fetch the `:host` from `Cingh::User#data`, which will be present
if initially parsed and doesn't rely on `Cinch` for synchronisation.

Resolves: https://github.com/logstash-plugins/logstash-input-irc/issues/9